### PR TITLE
Fix lifecycle registries

### DIFF
--- a/lifecycle/src/androidMain/kotlin/com/arkivanov/essenty/lifecycle/AndroidExt.kt
+++ b/lifecycle/src/androidMain/kotlin/com/arkivanov/essenty/lifecycle/AndroidExt.kt
@@ -27,8 +27,8 @@ private class EssentyLifecycleInterop(
     override fun subscribe(callbacks: EssentyLifecycle.Callbacks) {
         check(callbacks !in observerMap) { "Already subscribed" }
 
-        val observer = AndroidLifecycleObserver(callbacks)
-        this.observerMap[callbacks] = observer
+        val observer = AndroidLifecycleObserver(delegate = callbacks, onDestroy = { observerMap -= callbacks })
+        observerMap[callbacks] = observer
         delegate.addObserver(observer)
     }
 
@@ -51,7 +51,8 @@ private fun Lifecycle.State.toEssentyLifecycleState(): EssentyLifecycle.State =
     }
 
 private class AndroidLifecycleObserver(
-    private val delegate: EssentyLifecycle.Callbacks
+    private val delegate: EssentyLifecycle.Callbacks,
+    private val onDestroy: () -> Unit,
 ) : DefaultLifecycleObserver {
     override fun onCreate(owner: LifecycleOwner) {
         delegate.onCreate()
@@ -75,5 +76,6 @@ private class AndroidLifecycleObserver(
 
     override fun onDestroy(owner: LifecycleOwner) {
         delegate.onDestroy()
+        onDestroy.invoke()
     }
 }

--- a/lifecycle/src/androidMain/kotlin/com/arkivanov/essenty/lifecycle/AndroidExt.kt
+++ b/lifecycle/src/androidMain/kotlin/com/arkivanov/essenty/lifecycle/AndroidExt.kt
@@ -33,11 +33,9 @@ private class EssentyLifecycleInterop(
     }
 
     override fun unsubscribe(callbacks: EssentyLifecycle.Callbacks) {
-        val observer = observerMap.remove(callbacks)
-
-        check(observer != null) { "Not subscribed" }
-
-        delegate.removeObserver(observer)
+        observerMap.remove(callbacks)?.also {
+            delegate.removeObserver(it)
+        }
     }
 }
 

--- a/lifecycle/src/commonMain/kotlin/com/arkivanov/essenty/lifecycle/LifecycleRegistryImpl.kt
+++ b/lifecycle/src/commonMain/kotlin/com/arkivanov/essenty/lifecycle/LifecycleRegistryImpl.kt
@@ -69,6 +69,7 @@ internal class LifecycleRegistryImpl : LifecycleRegistry {
         checkState(State.CREATED)
         _state = State.DESTROYED
         callbacks.reversed().forEach(Callbacks::onDestroy)
+        callbacks = emptySet()
     }
 
     private fun checkState(required: State) {

--- a/lifecycle/src/commonMain/kotlin/com/arkivanov/essenty/lifecycle/LifecycleRegistryImpl.kt
+++ b/lifecycle/src/commonMain/kotlin/com/arkivanov/essenty/lifecycle/LifecycleRegistryImpl.kt
@@ -32,8 +32,6 @@ internal class LifecycleRegistryImpl : LifecycleRegistry {
     }
 
     override fun unsubscribe(callbacks: Callbacks) {
-        check(callbacks in this.callbacks) { "Not subscribed" }
-
         this.callbacks -= callbacks
     }
 


### PR DESCRIPTION
- Remove callbacks from local map in `EssentyLifecycleInterop` when Android lifecycle signalled `onDestroy`
- Don't throw exceptions when unsubscribe from `Lifecycles`
- Clear callbacks in `LifecycleRegistryImpl.onDestroy`