### PR TITLE
Deprecated InstanceKeeper#getOrCreate, added InstanceKeeper#provide and InstanceKeeper#providing extension functions

### DIFF
--- a/instance-keeper/api/android/instance-keeper.api
+++ b/instance-keeper/api/android/instance-keeper.api
@@ -36,6 +36,10 @@ public final class com/arkivanov/essenty/instancekeeper/InstanceKeeperDispatcher
 public final class com/arkivanov/essenty/instancekeeper/InstanceKeeperExtKt {
 	public static final fun getOrCreate (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
 	public static final fun getOrCreateSimple (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun provide (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
+	public static final fun provideSimple (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun providing (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
+	public static final fun providingSimple (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
 }
 
 public abstract interface class com/arkivanov/essenty/instancekeeper/InstanceKeeperOwner {

--- a/instance-keeper/api/jvm/instance-keeper.api
+++ b/instance-keeper/api/jvm/instance-keeper.api
@@ -29,6 +29,10 @@ public final class com/arkivanov/essenty/instancekeeper/InstanceKeeperDispatcher
 public final class com/arkivanov/essenty/instancekeeper/InstanceKeeperExtKt {
 	public static final fun getOrCreate (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
 	public static final fun getOrCreateSimple (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun provide (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper$Instance;
+	public static final fun provideSimple (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun providing (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
+	public static final fun providingSimple (Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
 }
 
 public abstract interface class com/arkivanov/essenty/instancekeeper/InstanceKeeperOwner {

--- a/instance-keeper/src/androidUnitTest/kotlin/com/arkivanov/essenty/instancekeeper/AndroidInstanceKeeperTest.kt
+++ b/instance-keeper/src/androidUnitTest/kotlin/com/arkivanov/essenty/instancekeeper/AndroidInstanceKeeperTest.kt
@@ -14,10 +14,10 @@ class AndroidInstanceKeeperTest {
     fun retains_instances() {
         val owner = TestOwner()
         var instanceKeeper = owner.instanceKeeper()
-        val instance1 = instanceKeeper.getOrCreate(key = "key", factory = ::TestInstance)
+        val instance1 = instanceKeeper.provide(key = "key", factory = ::TestInstance)
 
         instanceKeeper = owner.instanceKeeper()
-        val instance2 = instanceKeeper.getOrCreate(key = "key", factory = ::TestInstance)
+        val instance2 = instanceKeeper.provide(key = "key", factory = ::TestInstance)
 
         assertSame(instance1, instance2)
     }
@@ -26,10 +26,10 @@ class AndroidInstanceKeeperTest {
     fun GIVEN_discardRetainedInstances_is_true_on_restore_THEN_instances_not_retained() {
         val owner = TestOwner()
         var instanceKeeper = owner.instanceKeeper()
-        val instance1 = instanceKeeper.getOrCreate(key = "key", factory = ::TestInstance)
+        val instance1 = instanceKeeper.provide(key = "key", factory = ::TestInstance)
 
         instanceKeeper = owner.instanceKeeper(discardRetainedInstances = true)
-        val instance2 = instanceKeeper.getOrCreate(key = "key", factory = ::TestInstance)
+        val instance2 = instanceKeeper.provide(key = "key", factory = ::TestInstance)
 
         assertNotSame(instance1, instance2)
     }
@@ -38,7 +38,7 @@ class AndroidInstanceKeeperTest {
     fun GIVEN_discardRetainedInstances_is_true_on_restore_THEN_old_instances_destroyed() {
         val owner = TestOwner()
         val instanceKeeper = owner.instanceKeeper()
-        val instance1 = instanceKeeper.getOrCreate(key = "key", factory = ::TestInstance)
+        val instance1 = instanceKeeper.provide(key = "key", factory = ::TestInstance)
 
         owner.instanceKeeper(discardRetainedInstances = true)
 

--- a/instance-keeper/src/commonMain/kotlin/com/arkivanov/essenty/instancekeeper/InstanceKeeperExt.kt
+++ b/instance-keeper/src/commonMain/kotlin/com/arkivanov/essenty/instancekeeper/InstanceKeeperExt.kt
@@ -3,10 +3,25 @@ package com.arkivanov.essenty.instancekeeper
 import com.arkivanov.essenty.instancekeeper.InstanceKeeper.SimpleInstance
 
 /**
- * Returns a previously stored [InstanceKeeper.Instance] of type [T] with the given key,
+ * Returns a previously stored [InstanceKeeper.Instance] of type [T] with the given [key],
  * or creates and stores a new one if it doesn't exist.
  */
-inline fun <T : InstanceKeeper.Instance> InstanceKeeper.getOrCreate(key: Any, factory: () -> T): T {
+@Deprecated(
+    message = "Please use provide(key, factory) instead.",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith(
+        expression = "this.provide(key, factory)",
+        imports = ["com.arkivanov.essenty.instancekeeper.provide"],
+    ),
+)
+inline fun <T : InstanceKeeper.Instance> InstanceKeeper.getOrCreate(key: Any, factory: () -> T): T =
+    provide(key, factory)
+
+/**
+ * Returns a previously stored [InstanceKeeper.Instance] of type [T] with the given [key],
+ * or creates and stores a new one if it doesn't exist.
+ */
+inline fun <T : InstanceKeeper.Instance> InstanceKeeper.provide(key: Any, factory: () -> T): T {
     @Suppress("UNCHECKED_CAST") // Assuming the type per key is always the same
     var instance: T? = get(key) as T?
     if (instance == null) {
@@ -18,11 +33,40 @@ inline fun <T : InstanceKeeper.Instance> InstanceKeeper.getOrCreate(key: Any, fa
 }
 
 /**
+ * Lazily returns a previously stored [InstanceKeeper.Instance] of type [T] with the given [key],
+ * or creates and stores a new one if it doesn't exist.
+ */
+inline fun <T : InstanceKeeper.Instance> InstanceKeeper.providing(key: Any, crossinline factory: () -> T): Lazy<T> =
+    lazy { provide(key, factory) }
+
+/**
  * Returns a previously stored [InstanceKeeper.Instance] of type [T],
  * or creates and stores a new one if it doesn't exist. Uses `T::class` as key.
  */
+@Deprecated(
+    message = "Please use provide(factory) instead.",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith(
+        expression = "this.provide(factory)",
+        imports = ["com.arkivanov.essenty.instancekeeper.provide"],
+    ),
+)
 inline fun <reified T : InstanceKeeper.Instance> InstanceKeeper.getOrCreate(factory: () -> T): T =
-    getOrCreate(key = T::class, factory = factory)
+    provide(factory = factory)
+
+/**
+ * Returns a previously stored [InstanceKeeper.Instance] of type [T],
+ * or creates and stores a new one if it doesn't exist. Uses `T::class` as key.
+ */
+inline fun <reified T : InstanceKeeper.Instance> InstanceKeeper.provide(factory: () -> T): T =
+    provide(key = T::class, factory = factory)
+
+/**
+ * Lazily returns a previously stored [InstanceKeeper.Instance] of type [T],
+ * or creates and stores a new one if it doesn't exist. Uses `T::class` as key.
+ */
+inline fun <reified T : InstanceKeeper.Instance> InstanceKeeper.providing(crossinline factory: () -> T): Lazy<T> =
+    lazy { provide(factory = factory) }
 
 /**
  * Returns a previously stored instance of type [T] with the given key,
@@ -30,15 +74,67 @@ inline fun <reified T : InstanceKeeper.Instance> InstanceKeeper.getOrCreate(fact
  *
  * This overload is for simple cases when instance destroying is not required.
  */
+@Deprecated(
+    message = "Please use provideSimple(key, factory) instead.",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith(
+        expression = "this.provideSimple(key, factory)",
+        imports = ["com.arkivanov.essenty.instancekeeper.provideSimple"],
+    ),
+)
 inline fun <T> InstanceKeeper.getOrCreateSimple(key: Any, factory: () -> T): T =
-    getOrCreate(key = key) { SimpleInstance(factory()) }
-        .instance
+    provideSimple(key = key, factory = factory)
 
 /**
  * Returns a previously stored instance of type [T] with the given key,
+ * or creates and stores a new one if it doesn't exist.
+ *
+ * This overload is for simple cases when instance destroying is not required.
+ */
+inline fun <T> InstanceKeeper.provideSimple(key: Any, factory: () -> T): T =
+    provide(key = key) { SimpleInstance(factory()) }
+        .instance
+
+/**
+ * Lazily returns a previously stored instance of type [T] with the given [key],
+ * or creates and stores a new one if it doesn't exist.
+ *
+ * This overload is for simple cases when instance destroying is not required.
+ */
+inline fun <T> InstanceKeeper.providingSimple(key: Any, crossinline factory: () -> T): Lazy<T> =
+    lazy { provideSimple(key, factory) }
+
+/**
+ * Returns a previously stored instance of type [T],
  * or creates and stores a new one if it doesn't exist. Uses `T::class` as key.
  *
  * This overload is for simple cases when instance destroying is not required.
  */
+@Deprecated(
+    message = "Please use provideSimple(factory) instead.",
+    level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith(
+        expression = "this.provideSimple(factory)",
+        imports = ["com.arkivanov.essenty.instancekeeper.provideSimple"],
+    ),
+)
 inline fun <reified T> InstanceKeeper.getOrCreateSimple(factory: () -> T): T =
-    getOrCreateSimple(key = T::class, factory = factory)
+    provideSimple(factory = factory)
+
+/**
+ * Returns a previously stored instance of type [T],
+ * or creates and stores a new one if it doesn't exist. Uses `T::class` as key.
+ *
+ * This overload is for simple cases when instance destroying is not required.
+ */
+inline fun <reified T> InstanceKeeper.provideSimple(factory: () -> T): T =
+    provideSimple(key = T::class, factory = factory)
+
+/**
+ * Lazily returns a previously stored instance of type [T],
+ * or creates and stores a new one if it doesn't exist. Uses `T::class` as key.
+ *
+ * This overload is for simple cases when instance destroying is not required.
+ */
+inline fun <reified T> InstanceKeeper.providingSimple(crossinline factory: () -> T): Lazy<T> =
+    lazy { provideSimple(factory) }

--- a/instance-keeper/src/commonTest/kotlin/com/arkivanov/essenty/instancekeeper/InstanceKeeperExtTest.kt
+++ b/instance-keeper/src/commonTest/kotlin/com/arkivanov/essenty/instancekeeper/InstanceKeeperExtTest.kt
@@ -10,33 +10,33 @@ class InstanceKeeperExtTest {
     private val dispatcher = InstanceKeeperDispatcher()
 
     @Test
-    fun WHEN_getOrCreate_with_key_called_second_time_THEN_returns_same_instance() {
-        val thing1 = dispatcher.getOrCreate(key = "key") { SimpleInstance(Thing()) }.instance
-        val thing2 = dispatcher.getOrCreate(key = "key") { SimpleInstance(Thing()) }.instance
+    fun WHEN_provide_with_key_called_second_time_THEN_returns_same_instance() {
+        val thing1 = dispatcher.provide(key = "key") { SimpleInstance(Thing()) }.instance
+        val thing2 = dispatcher.provide(key = "key") { SimpleInstance(Thing()) }.instance
 
         assertSame(thing1, thing2)
     }
 
     @Test
-    fun WHEN_getOrCreate_without_key_called_second_time_THEN_returns_same_instance() {
-        val thing1 = dispatcher.getOrCreate { SimpleInstance(Thing()) }.instance
-        val thing2 = dispatcher.getOrCreate { SimpleInstance(Thing()) }.instance
+    fun WHEN_provide_without_key_called_second_time_THEN_returns_same_instance() {
+        val thing1 = dispatcher.provide { SimpleInstance(Thing()) }.instance
+        val thing2 = dispatcher.provide { SimpleInstance(Thing()) }.instance
 
         assertSame(thing1, thing2)
     }
 
     @Test
-    fun WHEN_getOrCreateSimple_with_key_called_second_time_THEN_returns_same_instance() {
-        val thing1 = dispatcher.getOrCreateSimple(key = "key", factory = ::Thing)
-        val thing2 = dispatcher.getOrCreateSimple(key = "key", factory = ::Thing)
+    fun WHEN_provideSimple_with_key_called_second_time_THEN_returns_same_instance() {
+        val thing1 = dispatcher.provideSimple(key = "key", factory = ::Thing)
+        val thing2 = dispatcher.provideSimple(key = "key", factory = ::Thing)
 
         assertSame(thing1, thing2)
     }
 
     @Test
-    fun WHEN_getOrCreateSimple_without_key_called_second_time_THEN_returns_same_instance() {
-        val thing1 = dispatcher.getOrCreateSimple(factory = ::Thing)
-        val thing2 = dispatcher.getOrCreateSimple(factory = ::Thing)
+    fun WHEN_provideSimple_without_key_called_second_time_THEN_returns_same_instance() {
+        val thing1 = dispatcher.provideSimple(factory = ::Thing)
+        val thing2 = dispatcher.provideSimple(factory = ::Thing)
 
         assertSame(thing1, thing2)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for obtaining or creating instances in the `InstanceKeeper` module, enhancing flexibility and usability.
- **Refactor**
	- Deprecated older `getOrCreate` functions in favor of new, more intuitively named `provide` functions, including lazy variants for deferred instance creation.
- **Tests**
	- Updated tests to reflect changes in instance creation methods for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->