### PR TITLE
Updated Reaktive to 2.1.0 and coroutines to 1.8.0

### DIFF
--- a/deps.versions.toml
+++ b/deps.versions.toml
@@ -3,7 +3,7 @@
 essenty = "2.0.0-beta01"
 kotlin = "1.9.21"
 kotlinxBinaryCompatibilityValidator = "0.13.2"
-kotlinxCoroutines = "1.8.0-RC" # Remove workaround from lifecycle-coroutines
+kotlinxCoroutines = "1.8.0"
 detektGradlePlugin = "1.23.3"
 junit = "4.13.2"
 androidGradle = "8.0.2"
@@ -12,7 +12,7 @@ androidxSavedstate = "1.2.1"
 androidxActivity = "1.8.1"
 jetbrainsKotlinxSerialization = "1.6.2"
 robolectric = "4.9.1"
-reaktive = "2.0.1" # Remove all workarounds when WASM is supported
+reaktive = "2.1.0"
 
 [libraries]
 

--- a/lifecycle-coroutines/build.gradle.kts
+++ b/lifecycle-coroutines/build.gradle.kts
@@ -22,9 +22,6 @@ kotlin {
         common.main.dependencies {
             implementation(project(":lifecycle"))
             implementation(deps.kotlinx.coroutinesCore)
-
-            // Workaround: https://github.com/Kotlin/kotlinx.coroutines/issues/3968
-            implementation("org.jetbrains.kotlinx:atomicfu:0.23.1")
         }
 
         common.test.dependencies {

--- a/lifecycle-reaktive/build.gradle.kts
+++ b/lifecycle-reaktive/build.gradle.kts
@@ -1,11 +1,7 @@
-import com.arkivanov.gradle.iosCompat
-import com.arkivanov.gradle.macosCompat
 import com.arkivanov.gradle.setupBinaryCompatibilityValidator
 import com.arkivanov.gradle.setupMultiplatform
 import com.arkivanov.gradle.setupPublication
 import com.arkivanov.gradle.setupSourceSets
-import com.arkivanov.gradle.tvosCompat
-import com.arkivanov.gradle.watchosCompat
 
 plugins {
     id("kotlin-multiplatform")
@@ -13,21 +9,7 @@ plugins {
     id("com.arkivanov.gradle.setup")
 }
 
-// Reaktive doesn't support wasm yet
-setupMultiplatform {
-    androidTarget()
-    jvm()
-    js {
-        browser()
-        nodejs()
-    }
-    linuxX64()
-    iosCompat()
-    watchosCompat()
-    tvosCompat()
-    macosCompat()
-}
-
+setupMultiplatform()
 setupPublication()
 setupBinaryCompatibilityValidator()
 

--- a/tools/check-publication/build.gradle.kts
+++ b/tools/check-publication/build.gradle.kts
@@ -30,10 +30,7 @@ kotlin {
             implementation("com.arkivanov.essenty:instance-keeper:$version")
             implementation("com.arkivanov.essenty:lifecycle:$version")
             implementation("com.arkivanov.essenty:lifecycle-coroutines:$version")
-
-            // Reaktive doesn't support WASM yet, exclude it from publication checks for now
-//            implementation("com.arkivanov.essenty:lifecycle-reaktive:$version")
-
+            implementation("com.arkivanov.essenty:lifecycle-reaktive:$version")
             implementation("com.arkivanov.essenty:state-keeper:$version")
         }
     }


### PR DESCRIPTION
Also removed related workarounds that are no longer needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `kotlinxCoroutines` to version "1.8.0" and `reaktive` to version "2.1.0" for improved performance and stability.
- **Refactor**
	- Simplified the setup for Reaktive by using `setupMultiplatform()` directly, enhancing maintainability.
- **Bug Fixes**
	- Fixed an issue related to kotlinx.coroutines by removing a specific workaround.
	- Addressed a publication check oversight by reintroducing `lifecycle-reaktive` to the checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->