### PR TITLE
Use typeOf instead as key of KClass in InstanceKeeper#getOrCreate

### DIFF
--- a/instance-keeper/src/commonMain/kotlin/com/arkivanov/essenty/instancekeeper/InstanceKeeperExt.kt
+++ b/instance-keeper/src/commonMain/kotlin/com/arkivanov/essenty/instancekeeper/InstanceKeeperExt.kt
@@ -1,6 +1,7 @@
 package com.arkivanov.essenty.instancekeeper
 
 import com.arkivanov.essenty.instancekeeper.InstanceKeeper.SimpleInstance
+import kotlin.reflect.typeOf
 
 /**
  * Returns a previously stored [InstanceKeeper.Instance] of type [T] with the given key,
@@ -19,10 +20,10 @@ inline fun <T : InstanceKeeper.Instance> InstanceKeeper.getOrCreate(key: Any, fa
 
 /**
  * Returns a previously stored [InstanceKeeper.Instance] of type [T],
- * or creates and stores a new one if it doesn't exist. Uses `T::class` as key.
+ * or creates and stores a new one if it doesn't exist. Uses `typeOf<T>()` as key.
  */
 inline fun <reified T : InstanceKeeper.Instance> InstanceKeeper.getOrCreate(factory: () -> T): T =
-    getOrCreate(key = T::class, factory = factory)
+    getOrCreate(key = typeOf<T>(), factory = factory)
 
 /**
  * Returns a previously stored instance of type [T] with the given key,
@@ -35,10 +36,10 @@ inline fun <T> InstanceKeeper.getOrCreateSimple(key: Any, factory: () -> T): T =
         .instance
 
 /**
- * Returns a previously stored instance of type [T] with the given key,
- * or creates and stores a new one if it doesn't exist. Uses `T::class` as key.
+ * Returns a previously stored instance of type [T],
+ * or creates and stores a new one if it doesn't exist. Uses `typeOf<T>()` as key.
  *
  * This overload is for simple cases when instance destroying is not required.
  */
 inline fun <reified T> InstanceKeeper.getOrCreateSimple(factory: () -> T): T =
-    getOrCreateSimple(key = T::class, factory = factory)
+    getOrCreateSimple(key = typeOf<T>(), factory = factory)

--- a/instance-keeper/src/commonTest/kotlin/com/arkivanov/essenty/instancekeeper/InstanceKeeperExtTest.kt
+++ b/instance-keeper/src/commonTest/kotlin/com/arkivanov/essenty/instancekeeper/InstanceKeeperExtTest.kt
@@ -1,7 +1,7 @@
 package com.arkivanov.essenty.instancekeeper
 
-import com.arkivanov.essenty.instancekeeper.InstanceKeeper.SimpleInstance
 import kotlin.test.Test
+import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 
 @Suppress("TestFunctionName")
@@ -10,36 +10,72 @@ class InstanceKeeperExtTest {
     private val dispatcher = InstanceKeeperDispatcher()
 
     @Test
-    fun WHEN_getOrCreate_with_key_called_second_time_THEN_returns_same_instance() {
-        val thing1 = dispatcher.getOrCreate(key = "key") { SimpleInstance(Thing()) }.instance
-        val thing2 = dispatcher.getOrCreate(key = "key") { SimpleInstance(Thing()) }.instance
+    fun WHEN_getOrCreate_with_same_key_called_second_time_THEN_returns_same_instance() {
+        val thing1 = dispatcher.getOrCreate(key = "key") { ThingInstance<Int>() }
+        val thing2 = dispatcher.getOrCreate(key = "key") { ThingInstance<Int>() }
 
         assertSame(thing1, thing2)
     }
 
     @Test
-    fun WHEN_getOrCreate_without_key_called_second_time_THEN_returns_same_instance() {
-        val thing1 = dispatcher.getOrCreate { SimpleInstance(Thing()) }.instance
-        val thing2 = dispatcher.getOrCreate { SimpleInstance(Thing()) }.instance
+    fun WHEN_getOrCreate_with_different_key_called_second_time_THEN_returns_new_instance() {
+        val thing1 = dispatcher.getOrCreate(key = "key1") { ThingInstance<Int>() }
+        val thing2 = dispatcher.getOrCreate(key = "key2") { ThingInstance<Int>() }
+
+        assertNotSame(thing1, thing2)
+    }
+
+    @Test
+    fun WHEN_getOrCreate_with_same_type_called_second_time_THEN_returns_same_instance() {
+        val thing1 = dispatcher.getOrCreate { ThingInstance<Int>() }
+        val thing2 = dispatcher.getOrCreate { ThingInstance<Int>() }
 
         assertSame(thing1, thing2)
     }
 
     @Test
-    fun WHEN_getOrCreateSimple_with_key_called_second_time_THEN_returns_same_instance() {
-        val thing1 = dispatcher.getOrCreateSimple(key = "key", factory = ::Thing)
-        val thing2 = dispatcher.getOrCreateSimple(key = "key", factory = ::Thing)
+    fun WHEN_getOrCreate_with_different_type_called_second_time_THEN_returns_new_instance() {
+        val thing1 = dispatcher.getOrCreate { ThingInstance<Int>() }
+        val thing2 = dispatcher.getOrCreate { ThingInstance<Float>() }
+
+        assertNotSame<ThingInstance<*>>(thing1, thing2)
+    }
+
+    @Test
+    fun WHEN_getOrCreateSimple_with_same_key_called_second_time_THEN_returns_same_instance() {
+        val thing1 = dispatcher.getOrCreateSimple(key = "key") { Thing<Int>() }
+        val thing2 = dispatcher.getOrCreateSimple(key = "key") { Thing<Int>() }
 
         assertSame(thing1, thing2)
     }
 
     @Test
-    fun WHEN_getOrCreateSimple_without_key_called_second_time_THEN_returns_same_instance() {
-        val thing1 = dispatcher.getOrCreateSimple(factory = ::Thing)
-        val thing2 = dispatcher.getOrCreateSimple(factory = ::Thing)
+    fun WHEN_getOrCreateSimple_with_different_key_called_second_time_THEN_returns_new_instance() {
+        val thing1 = dispatcher.getOrCreateSimple(key = "key1") { Thing<Int>() }
+        val thing2 = dispatcher.getOrCreateSimple(key = "key2") { Thing<Int>() }
+
+        assertNotSame(thing1, thing2)
+    }
+
+    @Test
+    fun WHEN_getOrCreateSimple_with_same_type_called_second_time_THEN_returns_same_instance() {
+        val thing1 = dispatcher.getOrCreateSimple { Thing<Int>() }
+        val thing2 = dispatcher.getOrCreateSimple { Thing<Int>() }
 
         assertSame(thing1, thing2)
     }
 
-    private class Thing
+    @Test
+    fun WHEN_getOrCreateSimple_with_different_type_called_second_time_THEN_returns_new_instance() {
+        val thing1 = dispatcher.getOrCreateSimple { Thing<Int>() }
+        val thing2 = dispatcher.getOrCreateSimple { Thing<Float>() }
+
+        assertNotSame<Thing<*>>(thing1, thing2)
+    }
+
+    @Suppress("unused")
+    private class Thing<out T>
+
+    @Suppress("unused")
+    private class ThingInstance<out T> : InstanceKeeper.Instance
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved instance management logic for more precise instance creation and retrieval.

- **Testing**
  - Updated test cases to ensure correct behavior with new instance management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->