### PR TITLE
Force jvmTarget 11 for all non-Android JVM targets

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.toString() == "com.arkivanov.gradle.setup") {
-                useModule("com.github.arkivanov:gradle-setup-plugin:310f7f6b99")
+                useModule("com.github.arkivanov:gradle-setup-plugin:1c9e347ca6")
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the Gradle setup plugin to a newer version, which may resolve existing issues and improve stability.
  
- **New Features**
	- The updated plugin may introduce new features or enhancements that improve build performance and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->