### PR TITLE
Added key parameter to StateKeeper Android extensions

### DIFF
--- a/state-keeper/api/android/state-keeper.api
+++ b/state-keeper/api/android/state-keeper.api
@@ -1,7 +1,11 @@
 public final class com/arkivanov/essenty/statekeeper/AndroidExtKt {
+	public static final fun StateKeeper (Landroidx/savedstate/SavedStateRegistry;Ljava/lang/String;ZLkotlin/jvm/functions/Function0;)Lcom/arkivanov/essenty/statekeeper/StateKeeper;
 	public static final fun StateKeeper (Landroidx/savedstate/SavedStateRegistry;ZLkotlin/jvm/functions/Function0;)Lcom/arkivanov/essenty/statekeeper/StateKeeper;
+	public static synthetic fun StateKeeper$default (Landroidx/savedstate/SavedStateRegistry;Ljava/lang/String;ZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/arkivanov/essenty/statekeeper/StateKeeper;
 	public static synthetic fun StateKeeper$default (Landroidx/savedstate/SavedStateRegistry;ZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/arkivanov/essenty/statekeeper/StateKeeper;
+	public static final fun stateKeeper (Landroidx/savedstate/SavedStateRegistryOwner;Ljava/lang/String;ZLkotlin/jvm/functions/Function0;)Lcom/arkivanov/essenty/statekeeper/StateKeeper;
 	public static final fun stateKeeper (Landroidx/savedstate/SavedStateRegistryOwner;ZLkotlin/jvm/functions/Function0;)Lcom/arkivanov/essenty/statekeeper/StateKeeper;
+	public static synthetic fun stateKeeper$default (Landroidx/savedstate/SavedStateRegistryOwner;Ljava/lang/String;ZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/arkivanov/essenty/statekeeper/StateKeeper;
 	public static synthetic fun stateKeeper$default (Landroidx/savedstate/SavedStateRegistryOwner;ZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/arkivanov/essenty/statekeeper/StateKeeper;
 }
 

--- a/state-keeper/src/androidMain/kotlin/com/arkivanov/essenty/statekeeper/AndroidExt.kt
+++ b/state-keeper/src/androidMain/kotlin/com/arkivanov/essenty/statekeeper/AndroidExt.kt
@@ -18,17 +18,40 @@ private const val KEY_STATE = "STATE_KEEPER_STATE"
 fun StateKeeper(
     savedStateRegistry: SavedStateRegistry,
     discardSavedState: Boolean = false,
-    isSavingAllowed: () -> Boolean = { true }
+    isSavingAllowed: () -> Boolean = { true },
+): StateKeeper =
+    StateKeeper(
+        savedStateRegistry = savedStateRegistry,
+        key = KEY_STATE,
+        discardSavedState = discardSavedState,
+        isSavingAllowed = isSavingAllowed,
+    )
+
+/**
+ * Creates a new instance of [StateKeeper] and attaches it to the provided AndroidX [SavedStateRegistry].
+ *
+ * @param savedStateRegistry a [SavedStateRegistry] to attach the returned [StateKeeper] to.
+ * @param key a key to access the provided [SavedStateRegistry], to be used by the returned [StateKeeper].
+ * @param discardSavedState a flag indicating whether any previously saved state should be discarded or not,
+ * default value is `false`.
+ * @param isSavingAllowed called before saving the state.
+ * When `true` then the state will be saved, otherwise it won't. Default value is `true`.
+ */
+fun StateKeeper(
+    savedStateRegistry: SavedStateRegistry,
+    key: String,
+    discardSavedState: Boolean = false,
+    isSavingAllowed: () -> Boolean = { true },
 ): StateKeeper {
     val dispatcher =
         StateKeeperDispatcher(
             savedState = savedStateRegistry
-                .consumeRestoredStateForKey(KEY_STATE)
+                .consumeRestoredStateForKey(key = key)
                 ?.getSerializableContainer(key = KEY_STATE)
                 ?.takeUnless { discardSavedState },
         )
 
-    savedStateRegistry.registerSavedStateProvider(KEY_STATE) {
+    savedStateRegistry.registerSavedStateProvider(key = key) {
         Bundle().apply {
             if (isSavingAllowed()) {
                 putSerializableContainer(key = KEY_STATE, value = dispatcher.save())
@@ -51,8 +74,29 @@ fun SavedStateRegistryOwner.stateKeeper(
     discardSavedState: Boolean = false,
     isSavingAllowed: () -> Boolean = { true },
 ): StateKeeper =
+    stateKeeper(
+        key = KEY_STATE,
+        discardSavedState = discardSavedState,
+        isSavingAllowed = isSavingAllowed,
+    )
+
+/**
+ * Creates a new instance of [StateKeeper] and attaches it to the AndroidX [SavedStateRegistry].
+ *
+ * @param key a key to access this [SavedStateRegistry], to be used by the returned [StateKeeper].
+ * @param discardSavedState a flag indicating whether any previously saved state should be discarded or not,
+ * default value is `false`.
+ * @param isSavingAllowed called before saving the state.
+ * When `true` then the state will be saved, otherwise it won't. Default value is `true`.
+ */
+fun SavedStateRegistryOwner.stateKeeper(
+    key: String,
+    discardSavedState: Boolean = false,
+    isSavingAllowed: () -> Boolean = { true },
+): StateKeeper =
     StateKeeper(
         savedStateRegistry = savedStateRegistry,
+        key = key,
         discardSavedState = discardSavedState,
         isSavingAllowed = isSavingAllowed
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new method overloads for `StateKeeper` and `stateKeeper`, allowing users to specify a key for enhanced state management.
	- Enhanced flexibility in state management with additional parameters in existing methods.

- **Bug Fixes**
	- Updated existing method signatures for better parameter handling and consistency.

- **Refactor**
	- Improved implementation logic to utilize the new key parameter for dynamic state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->